### PR TITLE
Make check refactor

### DIFF
--- a/src/components/cocktails/CocktailSearch.js
+++ b/src/components/cocktails/CocktailSearch.js
@@ -15,7 +15,7 @@ class CocktailSearch extends Component {
 
   handleFieldChange(e) {
     this.setState({[e.target.id]: e.target.value})
-    this.props.search(this.props.searchData, this.props.searchIngredients, e.target.value)
+    this.props.search(this.props.searchData, e.target.value)
   }
 
   clear = () => {
@@ -38,6 +38,5 @@ CocktailSearch.displayName = "CocktailSearch"
 CocktailSearch.propTypes = {
   search: PropTypes.func.isRequired,
   searchData: PropTypes.array.isRequired,
-  searchIngredients: PropTypes.array.isRequired,
   placeholder: PropTypes.string.isRequired,
 }

--- a/src/components/cocktails/CocktailsList.js
+++ b/src/components/cocktails/CocktailsList.js
@@ -15,7 +15,6 @@ class CocktailsList extends Component {
 
     let {
       cocktails,
-      cocktailIngredients,
       userCocktailsRelations,
       userInventory,
       userShoppingList,
@@ -26,16 +25,15 @@ class CocktailsList extends Component {
       return (
         <ListGroup>
           {
-            cocktails.map((cocktail, i) => {
-              //Find the userCocktail relationship that goes with the cocktail.
-              let thisUserCocktail = userCocktailsRelations.find(userCocktail => userCocktail.cocktail_id === cocktail.id)
-
+            cocktails.map(cocktail => {
+              let userCocktail = userCocktailsRelations.find(userCocktail => userCocktail.cocktail_id === cocktail.id)
               return (
                 <CocktailItem
-                  key={thisUserCocktail.id}
+                  // TODO: Just pass the usercocktail and break it apart inside the component?
+                  key={userCocktail.id}
+                  userCocktail={userCocktail}
                   cocktail={cocktail}
-                  ingredients={cocktailIngredients[i]}
-                  userCocktail={thisUserCocktail}
+                  ingredients={cocktail.ingredients}
                   userInventory={userInventory}
                   userShoppingList={userShoppingList}
                   getShoppingList={this.props.getShoppingList}
@@ -59,7 +57,6 @@ export default CocktailsList
 CocktailsList.displayName = "CocktailsList"
 CocktailsList.propTypes = {
   cocktails: PropTypes.array.isRequired,
-  cocktailIngredients: PropTypes.array.isRequired,
   userCocktailsRelations: PropTypes.array.isRequired,
   userInventory: PropTypes.array.isRequired,
   userShoppingList: PropTypes.array.isRequired,

--- a/src/components/cocktails/CocktailsView.js
+++ b/src/components/cocktails/CocktailsView.js
@@ -231,7 +231,7 @@ class CocktailsView extends Component {
 
       // Check if there is enough of each ingredient to make the specified quantity
       const amountNeededMl = Units.convert((currentIngredient.amount * c.quantity), currentIngredient.unit, "ml")
-      const prodAvailable = Units.convert((prod.amount_available + (prod.product.size * prod.quantity)), prod.product.unit, "ml")
+      const prodAvailable = Units.convert((Number(prod.amount_available) + (prod.product.size * prod.quantity)), prod.product.unit, "ml")
       const amountLeft = prodAvailable - amountNeededMl
       if (amountLeft < 0) canMake = false
     })
@@ -248,7 +248,7 @@ class CocktailsView extends Component {
         if (!prod) return this.props.toggleAlert("Warning", "Can't Make This Cocktail", "You're missing ingredients!")
 
         const amountNeededMl = Units.convert((currentIngredient.amount * c.quantity), currentIngredient.unit, "ml")
-        const prodAvailable = Units.convert((prod.amount_available + (prod.product.size * prod.quantity)), prod.product.unit, "ml")
+        const prodAvailable = Units.convert((Number(prod.amount_available) + (prod.product.size * prod.quantity)), prod.product.unit, "ml")
         const prodSizeMl = Units.convert(prod.product.size, prod.product.unit, "ml")
         const amountLeft = prodAvailable - amountNeededMl
         const quantityLeft = Math.ceil(amountLeft / prodSizeMl)

--- a/src/components/cocktails/IngredientFilter.js
+++ b/src/components/cocktails/IngredientFilter.js
@@ -23,7 +23,7 @@ class IngredientFilter extends Component {
     let id = e.target.id
     if (id !== "noFilter") id = Number(e.target.id)
     this.setState({ingredientFilter: id})
-    this.props.filterByIngredient(this.props.cocktails, this.props.cocktailIngredients, id)
+    this.props.filterByIngredient(this.props.cocktails, id)
   }
 
   clear = () => {

--- a/src/components/cocktails/discover/DiscoverList.js
+++ b/src/components/cocktails/discover/DiscoverList.js
@@ -20,10 +20,7 @@ class DiscoverList extends Component {
 
   render() {
 
-    let {
-      cocktails,
-      cocktailIngredients
-    } = this.props
+    let { cocktails } = this.props
 
     if (this.state.loaded) {
 
@@ -31,12 +28,12 @@ class DiscoverList extends Component {
         return (
           <ListGroup>
             {
-              cocktails.map((cocktail, i) => {
+              cocktails.map(cocktail => {
                 return (
                   <DiscoverItem
                     key={cocktail.id}
                     cocktail={cocktail}
-                    ingredients={cocktailIngredients[i]}
+                    ingredients={cocktail.ingredients}
                     getUserCocktailData={this.props.getUserCocktailData}
                     allMinusUserCocktails={this.props.allMinusUserCocktails}
                   />
@@ -62,7 +59,6 @@ DiscoverList.displayName = "DiscoverList"
 DiscoverList.propTypes = {
   getDiscoverCocktails: PropTypes.func.isRequired,
   cocktails: PropTypes.array.isRequired,
-  cocktailIngredients: PropTypes.array.isRequired,
   getUserCocktailData: PropTypes.func.isRequired,
   allMinusUserCocktails: PropTypes.func.isRequired
 }


### PR DESCRIPTION
Now that ingredients are automatically included in cocktails from the API, cleaned up areas that were using a separate ingredients query.

When making cocktails from the tab, refactored the process for checking ingredients and only making the cocktail if everything is still available. 

creates a product map the first time through when it's checking so that it doesn't have to check everything again when each cocktail is made. Basically, made it DRYer since the same thing was being repeated twice.